### PR TITLE
Tested Chrome CSS Grid Overflow Bug Fixes - Problem Fixed

### DIFF
--- a/skills.html
+++ b/skills.html
@@ -103,10 +103,22 @@
                             </div>
                         </div>
                         <div class="sun-orbit column_9-4 row_8-2">
-                            <div class="sun"></div>s
+                            <div class="sun"></div>
                         </div>
 
-                        
+                        <section class="skills-list-container">
+
+                            <button class="skill-button html">HTML5</button>
+                            <button class="skill-button css">CSS3</button>
+                            <button class="skill-button js">JavaScript</button>
+                            <button class="skill-button scss">SCSS</button>
+                            <button class="skill-button less">Less</button>
+                            <button class="skill-button rd">Responsive Design</button>
+                            <button class="skill-button ink">Inkscape</button>
+                            <button class="skill-button il">Illustrator</button>
+                            <button class="skill-button ps">Photoshop</button>
+
+                        </section>
 
                     </div>
 


### PR DESCRIPTION
Grid Overflow Bug on Google Chrome is fixed.  It was troubling to see that the about page would be ineffective and rendered useless by this layout bug.  Fixed it using a fixed minmax rule for each of the rows for the nested grid system in the elevator.  You can replicate the problem by changing each to the total number of rows with a setting of '1fr' on the grid-template-rows.